### PR TITLE
proto2: keep `required` field qualifier

### DIFF
--- a/pkg/protofmt/columns.go
+++ b/pkg/protofmt/columns.go
@@ -100,11 +100,10 @@ func (p *columnsPrinter) VisitImport(i *proto.Import) {
 func (p *columnsPrinter) VisitNormalField(f *proto.NormalField) {
 	if f.Repeated {
 		p.cols = append(p.cols, leftAligned("repeated "))
-	} else {
-		p.cols = append(p.cols, alignedEmpty)
-	}
-	if f.Optional {
+	} else if f.Optional {
 		p.cols = append(p.cols, leftAligned("optional "))
+	} else if f.Required {
+		p.cols = append(p.cols, leftAligned("required "))
 	} else {
 		p.cols = append(p.cols, alignedEmpty)
 	}


### PR DESCRIPTION
Regarding testing - running https://github.com/emicklei/proto-contrib/blob/e7fc5dfb8a348d29a04591336c08bca08b53c0c7/cmd/protofmt/format.sh shows the problem - I am just not sure how/if it is executed on CI?