### PR TITLE
Protofmt fix whitespace

### DIFF
--- a/pkg/protofmt/aligned.go
+++ b/pkg/protofmt/aligned.go
@@ -38,7 +38,7 @@ var (
 	alignedSpace       = leftAligned(" ")
 	alignedComma       = leftAligned(", ")
 	alignedEmpty       = leftAligned("")
-	alignedSemicolon   = leftAligned(";")
+	alignedSemicolon   = notAligned(";")
 )
 
 func leftAligned(src string) aligned  { return aligned{src, true, true} }

--- a/pkg/protofmt/formatter.go
+++ b/pkg/protofmt/formatter.go
@@ -126,8 +126,8 @@ func (f *Formatter) VisitOption(o *proto.Option) {
 
 // VisitPackage formats a Package.
 func (f *Formatter) VisitPackage(p *proto.Package) {
-	f.nl()
 	f.printAsGroups([]proto.Visitee{p})
+	f.nl()
 }
 
 // VisitService formats a Service.
@@ -149,6 +149,7 @@ func (f *Formatter) VisitSyntax(s *proto.Syntax) {
 	f.begin("syntax", s)
 	fmt.Fprintf(f.w, "syntax = %q", s.Value)
 	f.endWithComment(s.InlineComment)
+	f.nl()
 }
 
 // VisitOneof formats a Oneof.


### PR DESCRIPTION
This patch removes a trailing whitespace after the semicolon, if one of the following lines contains an option.

```
message X {
    int32 x = 1; <-- trailing whitespace
    int32 y = 2 [deprecated = true];
}
```

It also adds a blank line between `syntax` and `package` and `import`. Otherwise, it looks like this:

```
syntax = "proto3";

package x;
import "y.proto";
import "z.proto";
...
```

However, if there are no imports then there will be two blank lines between `package` and `message` for example. I think the parser either needs to have more context so that when you render `package` it knows whether to add a blank line or not or the `import`s need to be processed as a group or something needs to indicate that it is the first import so that you can add a blank line before the `import` block. Please feel free to have a better solution.

```
syntax = "proto3";

package x;
<-- blank line
<-- blank line
message X {}
```

but 

```
syntax = "proto3";

package x;

import "y.proto"

message X {}
```
