### PR TITLE
left align types like in gofmt

### DIFF
--- a/cmd/protofmt/README.md
+++ b/cmd/protofmt/README.md
@@ -33,6 +33,7 @@ Different structural top level definitions (message,service,enum) are separated 
 	message Z {}
 
 	enum E {}
+
 Comments are preceeded with an empty line unless it is defined after a statement.
 
 	// nice message to send
@@ -46,10 +47,10 @@ Fields in messages and enums, rpc-s in services are all formatted in a columnar 
 
 	repeated sfixed32 packed_sfixed32 =  98 [packed = true];
 	repeated sfixed64 packed_sfixed64 =  99 [packed = true];
-	repeated    float packed_float    = 100 [packed = true];
-	repeated   double packed_double   = 101 [packed = true];
+	repeated float    packed_float    = 100 [packed = true];
+	repeated double   packed_double   = 101 [packed = true];
 
-This example shows that field types are right aligned.
+This example shows that field types are left aligned.
 Field names are left aligned.
 Field sequence numbers are right aligned.
 
@@ -57,15 +58,14 @@ Field sequence numbers are right aligned.
 Embedded options (specified for fields) have a compact format without special alignment.
 
 	message Defaults {
-	  optional   bool default_bool   = 1 [default = true   ];
+	  optional bool   default_bool   = 1 [default = true   ];
 	  optional string default_string = 2 [default = "hello"];
 	}
 
 Top level options have right aligned names and values.
 
-	option         optimize_for =           SPEED;
+	option optimize_for         =           SPEED;
 	option java_outer_classname = "UnittestProto";
-
 
 #### RPCs in services
 Request and Response types of rpc elements are left aligned.
@@ -78,14 +78,16 @@ Closing brackets are right aligned.
 	}
 
 ## Docker
+
 A Docker image is available on Dockerhub.
 It can be used as part of your continuous integration build pipeline.
 
-### build 
+### build
+
 	GOOS=linux go build
 	docker build -t emicklei/protofmt .
 
 ### run
-	 docker run -v $(pwd):/data emicklei/protofmt /data/YOUR.proto	
+	 docker run -v $(pwd):/data emicklei/protofmt /data/YOUR.proto
 
-© 2017, [ernestmicklei.com](http://ernestmicklei.com).  MIT License.     
+© 2017, [ernestmicklei.com](http://ernestmicklei.com).  MIT License.

--- a/pkg/protofmt/columns.go
+++ b/pkg/protofmt/columns.go
@@ -108,7 +108,7 @@ func (p *columnsPrinter) VisitNormalField(f *proto.NormalField) {
 	} else {
 		p.cols = append(p.cols, alignedEmpty)
 	}
-	p.cols = append(p.cols, rightAligned(f.Type), alignedSpace, leftAligned(f.Name), alignedEquals, rightAligned(strconv.Itoa(f.Sequence)))
+	p.cols = append(p.cols, leftAligned(f.Type), alignedSpace, leftAligned(f.Name), alignedEquals, rightAligned(strconv.Itoa(f.Sequence)))
 	if len(f.Options) > 0 {
 		p.cols = append(p.cols, leftAligned(" ["))
 		for i, each := range f.Options {
@@ -140,7 +140,7 @@ func (p *columnsPrinter) VisitComment(e *proto.Comment) {}
 func (p *columnsPrinter) VisitOneof(o *proto.Oneof)     {}
 func (p *columnsPrinter) VisitOneofField(o *proto.OneOfField) {
 	p.cols = append(p.cols,
-		rightAligned(o.Type),
+		leftAligned(o.Type),
 		alignedSpace,
 		leftAligned(o.Name),
 		alignedEquals,
@@ -207,7 +207,7 @@ func (p *columnsPrinter) VisitMapField(f *proto.MapField) {
 	p.cols = append(p.cols,
 		alignedEmpty, // no repeated
 		alignedEmpty, // no optional
-		rightAligned(fmt.Sprintf("map <%s,%s>", f.KeyType, f.Type)),
+		leftAligned(fmt.Sprintf("map <%s,%s>", f.KeyType, f.Type)),
 		alignedSpace,
 		leftAligned(f.Name),
 		// notAligned("map <"),


### PR DESCRIPTION
This patch left aligns the types in messages since this is more in line with `gofmt`. Not sure if you want to merge this that's why I didn't spend a lot of time. ~~I would need to update other cases `services` and the README or we make this optional.~~

I think I got all the cases. 

Let me know what you think.

```
message Event {
  string device_id =  1;
  int64  time_ms   =  2;
}
```

instead of

```
message Event {
  string device_id =  1;
   int64 time_ms   =  2;
}
```
